### PR TITLE
modified Notifications patterns to make them optional

### DIFF
--- a/src/schema.json
+++ b/src/schema.json
@@ -144,19 +144,19 @@
       "properties": {
         "Completed": {
           "type": "string",
-          "pattern": "arn:aws:sns:(\\w+-\\w+-\\d+):[0-9]*:[\\w-]*"
+          "pattern": "^arn:aws:sns:(\\w+-\\w+-\\d+):[0-9]*:[\\w-]*$|^$"
         },
         "Error": {
           "type": "string",
-          "pattern": "arn:aws:sns:(\\w+-\\w+-\\d+):[0-9]*:[\\w-]*"
+          "pattern": "^arn:aws:sns:(\\w+-\\w+-\\d+):[0-9]*:[\\w-]*$|^$"
         },
         "Progressing": {
           "type": "string",
-          "pattern": "arn:aws:sns:(\\w+-\\w+-\\d+):[0-9]*:[\\w-]*"
+          "pattern": "^arn:aws:sns:(\\w+-\\w+-\\d+):[0-9]*:[\\w-]*$|^$"
         },
         "Warning": {
           "type": "string",
-          "pattern": "arn:aws:sns:(\\w+-\\w+-\\d+):[0-9]*:[\\w-]*"
+          "pattern": "^arn:aws:sns:(\\w+-\\w+-\\d+):[0-9]*:[\\w-]*$|^$"
         }
       }
     }


### PR DESCRIPTION
JSON schema currently forces you to provide values for all of the `Notifications` fields if you specify any of them. E.g., if you only specify `Notifications.Completed` and `Notifications.Error`, the regex on `Notifications.Progressing` will fail.
